### PR TITLE
- added explicit keyword to RTTRPluginFactory constructor

### DIFF
--- a/include/traact/facade/rttr/RTTRPluginFactory.cpp
+++ b/include/traact/facade/rttr/RTTRPluginFactory.cpp
@@ -220,7 +220,12 @@ traact::facade::RTTRPluginFactory::ComponentPtr traact::facade::RTTRPluginFactor
 }
 
 traact::facade::RTTRPluginFactory::RTTRPluginFactory() {
-    plugin_directories_ = getenv("TRAACT_PLUGIN_PATHS");
+    auto plugin_dirs = getenv("TRAACT_PLUGIN_PATHS");
+    if (plugin_dirs != nullptr) {
+        plugin_directories_ = plugin_dirs;
+    } else {
+        throw std::runtime_error(std::string("Missing environment variable: TRAACT_PLUGIN_PATH"));
+    }
     init();
 }
 

--- a/include/traact/facade/rttr/RTTRPluginFactory.h
+++ b/include/traact/facade/rttr/RTTRPluginFactory.h
@@ -51,7 +51,7 @@ namespace traact::facade {
 
         RTTRPluginFactory();
 
-        RTTRPluginFactory(const std::string &pluginDirectories);
+        explicit RTTRPluginFactory(const std::string &pluginDirectories);
 
         ~RTTRPluginFactory() = default;
 


### PR DESCRIPTION
This fix adds a check if the environment variable is set if no library search paths are given in the constructor and throws an error if no environment variable was set.

commits:
- added check if TRAACT_PLUGIN_PATHS is not set and no plugin-paths are provided manually